### PR TITLE
Cache & hash image dir listing for performance

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Steam Search",
   "Description": "Search and launch your Steam Game library",
   "Author": "Garulf",
-  "Version": "7.2.0",
+  "Version": "8.0.0",
   "Language": "executable",
   "Website": "https://github.com/Garulf/Steam-Search",
   "IcoPath": "run.exe",

--- a/plugin/library.py
+++ b/plugin/library.py
@@ -23,6 +23,7 @@ class Library:
         Return a list of games in this library.
         """
         games = []
+        image_dir = LibraryImageDir(Path(self.steam.path).joinpath('appcache', 'librarycache'))
         for appmanifest in Path(self.path).joinpath('steamapps').glob('appmanifest_*.acf'):
             try:
                 manifest = VDF(appmanifest)
@@ -45,22 +46,47 @@ class Library:
                         path=Path(self.path).joinpath(
                             manifest['AppState']['installdir']),
                         id=manifest['AppState']['appid'],
-                        image_dir=Path(self.steam.path).joinpath(
-                            'appcache', 'librarycache'),
+                        image_dir=image_dir,
                     )
                 )
         return games
 
+class LibraryImageDir:
+    """
+    Caches the filesystem access of a library image directory
+    """
+
+    def __init__(self, image_dir: Union[str, Path]):
+        image_dir = Path(image_dir)
+        self.grid = image_dir.name == 'grid'
+        self._files_cache = {}
+        self._iterdir = image_dir.iterdir()
+
+    def get_image(self, id: str, type: str, sep='_') -> Path:
+        if self.grid:
+            # Grid images use short ID format
+            id = self.short_id()
+
+        prefix = f'{id}{sep}{type}'
+        if prefix in self._files_cache:
+            return self._files_cache[prefix]
+        else:
+            for file in self._iterdir:
+                haystack_prefix = file.name.split(".", 1)[0]
+                self._files_cache[haystack_prefix] = file
+                if prefix == haystack_prefix:
+                    return file
+            return None
 
 class LibraryItem:
     """
     Base class for all library items.
     """
 
-    def __init__(self, name: str, path: Union[str, Path], image_dir: Union[str, Path], id: str = None):
+    def __init__(self, name: str, path: Union[str, Path], image_dir: LibraryImageDir, id: str = None):
         self.name = name
         self.path = Path(path)
-        self.image_dir = Path(image_dir)
+        self.image_dir = image_dir
         self._id = id
         self._image_id = self.id
 
@@ -87,11 +113,7 @@ class LibraryItem:
         webbrowser.open(self.uri())
 
     def get_image(self, type: str, sep='_') -> Path:
-        id = self.id
-        if Path(self.image_dir).name == 'grid':
-            # Grid images use short ID format
-            id = self.short_id()
-        return next(Path(self.image_dir).glob(f'{id}{sep}{type}.*'), None)
+        return self.image_dir.get_image(self.id, type, sep)
 
     @cached_property
     def icon(self) -> Path:

--- a/plugin/library.py
+++ b/plugin/library.py
@@ -63,9 +63,6 @@ class LibraryImageDir:
         self._iterdir = image_dir.iterdir()
 
     def get_image(self, id: str, type: str, sep='_') -> Path:
-        if self.grid:
-            # Grid images use short ID format
-            id = self.short_id()
 
         prefix = f'{id}{sep}{type}'
         if prefix in self._files_cache:
@@ -113,7 +110,11 @@ class LibraryItem:
         webbrowser.open(self.uri())
 
     def get_image(self, type: str, sep='_') -> Path:
-        return self.image_dir.get_image(self.id, type, sep)
+        id = self.id
+        if self.image_dir.grid:
+            # Grid images use the short version ID
+            id = self.short_id()
+        return self.image_dir.get_image(id, type, sep)
 
     @cached_property
     def icon(self) -> Path:

--- a/plugin/library.py
+++ b/plugin/library.py
@@ -112,7 +112,7 @@ class LibraryItem:
     def get_image(self, type: str, sep='_') -> Path:
         id = self.id
         if self.image_dir.grid:
-            # Grid images use the short version ID
+            # Grid images use the short ID
             id = self.short_id()
         return self.image_dir.get_image(id, type, sep)
 

--- a/plugin/loginusers.py
+++ b/plugin/loginusers.py
@@ -5,7 +5,7 @@ from distutils.util import strtobool
 from collections import UserList
 
 from .vdfs import VDF
-from .library import LibraryItem
+from .library import LibraryItem, LibraryImageDir
 if TYPE_CHECKING:
     from steam import Steam
 
@@ -75,12 +75,13 @@ class LoginUser:
         split = _shortcuts.split(b'AppName\x00')[1:]
         if len(split) == 0:
             return _list
+        image_dir = LibraryImageDir(self.grid_path)
         for shortcut in _shortcuts.split(b'AppName\x00')[1:]:
             _list.append(
                 LibraryItem(
                     name=shortcut.split(b'\x00')[0].decode('utf-8'),
                     path=shortcut.split(b'\x00')[2].decode('utf-8'),
-                    image_dir=self.grid_path
+                    image_dir=image_dir
                 )
             )
         return _list


### PR DESCRIPTION
Image lookup was taking nearly a second on my machine/library, this reduces it to almost nothing.

Creates a new class LibraryImageDir to manage the statefulness of caching and lazily build a dictionary of filename prefixes for fast lookup.