### PR TITLE
Bump steam-client to 6.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyflowlauncher==1.0.1
-steam-client==5.0.2
+steam-client==6.0.0

--- a/src/plugin/__main__.py
+++ b/src/plugin/__main__.py
@@ -9,7 +9,7 @@ steam = steam_from_registry()
 
 @plugin.on_method
 async def query(query: str):
-    for game in steam.library.games():
+    for game in steam.library.all_apps():
         score = 0
         if query:
             match_data = await plugin.launcher.api.fuzzy_search(


### PR DESCRIPTION
## Summary
- Upgrade `steam-client` from 5.0.2 to 6.0.0
- Update library iteration to the new `all_apps()` API (replaces `games()`), which includes non-Steam shortcuts

Closes #57
Closes #59

## Test plan
- Packaged the plugin locally with steam-client 6.0.0 and verified the plugin's imports (`steam_from_registry`, `run_game_id`) against the new version