### PR TITLE
Switch to python_v2 plugin runtime, bump to 12.0.0

### DIFF
--- a/data/plugin.json
+++ b/data/plugin.json
@@ -4,8 +4,8 @@
   "Name": "Steam Search",
   "Description": "Search and launch your Steam Game library",
   "Author": "Garulf",
-  "Version": "11.0.2",
-  "Language": "python",
+  "Version": "12.0.0",
+  "Language": "python_v2",
   "Website": "https://github.com/Garulf/Steam-Search",
   "IcoPath": "icon.png",
   "ExecuteFileName": "run.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyflowlauncher==1.0.1
+pyflowlauncher==1.0.2
 steam-client==6.0.0


### PR DESCRIPTION
## Summary
- Switch `plugin.json` Language to `python_v2`
- Bump `pyflowlauncher` from 1.0.1 to 1.0.2
- Bump plugin version to 12.0.0 (major, due to the plugin runtime switch)

## Test plan
- Packaged the plugin locally with pyflowlauncher 1.0.2 (PyPI wheel) and steam-client 6.0.0 for local testing in Flow Launcher